### PR TITLE
Fix gitignore to work correctly with the silver searcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-/build
-/node_modules
-/tmp
+build/
+node_modules/
+tmp/
+dist/
+.tags


### PR DESCRIPTION
Hi

Folders like node_modules were not ignored when `ag` (the silver searcher) is used.
The pull request fixes that and adds ignore for `.tags' file. 

Thanks