### PR TITLE
removeEmptyRanks - replace _.has() method with more generic check

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -163,7 +163,7 @@ function removeEmptyRanks(g) {
   var layers = [];
   _.each(g.nodes(), function(v) {
     var rank = g.node(v).rank - offset;
-    if (!_.has(layers, rank)) {
+    if (!layers[rank]) {
       layers[rank] = [];
     }
     layers[rank].push(v);


### PR DESCRIPTION
Since [lodash v 3.9.0](https://github.com/lodash/lodash/wiki/Changelog#v390) _.has treats sparse arrays as dense which is why I get error using dagre-d3 with browserify (I have separate js bundle with latest lodash I use so I excluded v 2.4.1 that comes with dagre/dagre-d3).

This replaces _.has method with more generic falsy check on array. Comparison test [here](http://codepen.io/teodragovic/pen/zGZLpP?editors=001) and [here](http://codepen.io/teodragovic/pen/bdqjRG?editors=001).