### PR TITLE
Add webpack support to dagre

### DIFF
--- a/lib/graphlib.js
+++ b/lib/graphlib.js
@@ -2,7 +2,7 @@
 
 var graphlib;
 
-if (require) {
+if (typeof require === 'function') {
   try {
     graphlib = require("graphlib");
   } catch (e) {}

--- a/lib/lodash.js
+++ b/lib/lodash.js
@@ -2,7 +2,7 @@
 
 var lodash;
 
-if (require) {
+if (typeof require === 'function') {
   try {
     lodash = require("lodash");
   } catch (e) {}


### PR DESCRIPTION
The use of require in the graphlib and lodash causes a warning in webpack when using dagre.